### PR TITLE
Add support for hsm git repo using http without `.git` suffix

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,33 +10,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
   publish-to-pypi:
     name: >-
       Publish to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
-    - build
+      - build
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -45,19 +45,19 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-to-testpypi:
     name: Publish to TestPyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
-    - build
+      - build
     runs-on: ubuntu-latest
 
     environment:
@@ -68,12 +68,12 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ By default, the hsm-orchestrator stores configuration at:
 * **macOS**: `~/Library/Application Support/hsm-orchestrator/config.ini`
 * **Windows**: `%LOCALAPPDATA%\Mozilla\hsm-orchestrator\config.ini`
 
-You may need to create the `hsm-orchestrator` directory in order to create the `config.ini` within it. 
+You may need to create the `hsm-orchestrator` directory in order to create the `config.ini` within it.
 
 ### `config.ini` Contents
 
-Within that `config.ini` file, you can indicate the location of your local [`mozilla-services/hsm`](https://github.com/mozilla-services/hsm) git repo
+Within that `config.ini` file, you can indicate the location of your local [
+`mozilla-services/hsm`](https://github.com/mozilla-services/hsm) git repo
 and the `csrs` directory within it.
 
 For example if the path to your local `mozilla-services/hsm` repo on your macOS workstation was `~/Documents/hsm`,
@@ -115,11 +116,12 @@ files off of the USB stick and into the correct directories in the hsm git repo.
 
 1. Create a new `.csr` + `.cnf` file in the [`csrs`](https://github.com/mozilla-services/hsm/tree/main/csrs) directory
    of the `hsm` git repo.
-    * In the `.cnf` file, the `certs`, `database`, `new_certs_dir`, `certificate` and `serial` settings in the default_ca
-      section (often called `CA_default`) are relative paths pointing to the current working directory. For example,
-      `serial` should have a value like `./serial` or `$dir/serial` where `$dir` is set elsewhere to `.`.
+    * In the `.cnf` file, the `certs`, `database`, `new_certs_dir`, `certificate` and `serial` settings in the
+      default_ca section (often called `CA_default`) are relative paths pointing to the current working directory. For
+      example, `serial` should have a value like `./serial` or `$dir/serial` where `$dir` is set elsewhere to `.`.
     * In the `.cnf` file, the `certificate` setting should have the value of the CA certificate `.crt` filename in the
-      `hsm` git repo's [`certificate-authorities`](https://github.com/mozilla-services/hsm/tree/main/certificate-authorities)
+      `hsm` git repo's
+      [`certificate-authorities`](https://github.com/mozilla-services/hsm/tree/main/certificate-authorities)
       tree.
     * In the `.cnf` file, the `private_key` setting should have the value of the offline HSM application key name
       (instead of a filename as is typically the case). The names of the offline HSM application key names can be found

--- a/hsm_orchestrator/__init__.py
+++ b/hsm_orchestrator/__init__.py
@@ -43,7 +43,7 @@ class HsmOrchestrator:
 
         """
         self.orchestrator_config_filename = orchestrator_config_filename
-        self.REMOTE_URL_SUFFIX = "mozilla-services/hsm.git"
+        self.remote_url_pattern = re.compile(r".*mozilla-services/hsm(\.git)?")
         self.repo_dir = kwargs["repo_dir"] if "repo_dir" in kwargs else None
         self.csr_dir = kwargs["csr_dir"] if "csr_dir" in kwargs else None
 
@@ -313,7 +313,7 @@ class HsmOrchestrator:
 
         """
         repo = git.Repo(self.repo_dir)
-        git_remote_name = validators.validate_environment(repo, self.REMOTE_URL_SUFFIX)
+        git_remote_name = validators.validate_environment(repo, self.remote_url_pattern)
 
         if not skip_git_fetch:
             # Git fetch

--- a/hsm_orchestrator/validators.py
+++ b/hsm_orchestrator/validators.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Any
 
@@ -61,7 +62,7 @@ def validate_csr_dir(ctx: click.Context, param: click.Parameter, value: Any) -> 
     return csr_dir
 
 
-def validate_environment(repo: git.repo.base.Repo, remote_url_suffix: str) -> str:
+def validate_environment(repo: git.repo.base.Repo, remote_url_pattern: re.Pattern) -> str:
     """Validate the environment
 
     Look that there's an expected git remote and that we're not running on the
@@ -85,13 +86,13 @@ def validate_environment(repo: git.repo.base.Repo, remote_url_suffix: str) -> st
     # Check git remote
     remote_name = None
     for remote in repo.remotes:
-        if remote.url.endswith(remote_url_suffix):
+        if remote_url_pattern.search(remote.url) is not None:
             remote_name = remote.name
     if remote_name is None:
         raise exceptions.RepoNotReady(
-            f"The {repo.working_tree_dir} repo has no remotes configured that end in"
-            f" {remote_url_suffix}. Make sure the repo is setup with an 'origin' remote"
-            " pointing to the GitHub repo."
+            f"The {repo.working_tree_dir} repo has no remotes configured that match "
+            f"'{remote_url_pattern}'. Make sure the repo is setup with an 'origin' "
+            f"remote pointing to the GitHub repo."
         )
 
     return remote_name

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -208,13 +208,96 @@ def test_git_repo_missing_remote(tmp_path, datafiles):
         assert type(result.exception) is type(exceptions.RepoNotReady("foo"))
         assert (
             re.search(
-                r"The .* repo has no remotes configured that end in"
-                r" mozilla-services/hsm\.git. Make sure the repo is setup with an"
+                r"The .* repo has no remotes configured that match "
+                r".* Make sure the repo is setup with an"
                 r" 'origin' remote pointing to the GitHub repo\.",
                 repr(result.exception),
                 flags=re.MULTILINE,
             )
             is not None
+        )
+
+
+@pytest.mark.datafiles(FIXTURE_DIR / "example.csr")
+def test_git_repo_remotes(tmp_path, datafiles):
+    runner = CliRunner()
+    with runner.isolated_filesystem(tmp_path):
+        orchestrator_config_file, repo_dir, csr_dir = set_up_config(
+            tmp_path, configure_paths=True
+        )
+        csr_dir.mkdir()
+        Path(repo_dir / ".git").mkdir()
+        with Path(repo_dir / ".git" / "config").open("w") as f:
+            f.write("[init]\n   defaultBranch = main\n")
+            f.write('[remote "origin"]\n')
+            f.write("url = git@github.com:octocat/someotherrepo.git\n")
+            f.write("fetch = +refs/heads/*:refs/remotes/origin/*\n")
+        repo = Repo.init(repo_dir)
+        Path(repo_dir / "certs_issued").mkdir()
+        repo.index.commit("Adding certs_issued")
+        csr_file = csr_dir / "example.csr"
+        Path(datafiles / "example.csr").rename(csr_file)
+        result = runner.invoke(
+            main, ["check", "--skip-git-fetch", "--config", orchestrator_config_file]
+        )
+        assert type(result.exception) is type(exceptions.RepoNotReady("foo"))
+        assert (
+            re.search(
+                r"The .* repo has no remotes configured that match "
+                r".* Make sure the repo is setup with an"
+                r" 'origin' remote pointing to the GitHub repo\.",
+                repr(result.exception),
+                flags=re.MULTILINE,
+            )
+            is not None
+        )
+        with Path(repo_dir / ".git" / "config").open("w") as f:
+            f.write("[init]\n   defaultBranch = main\n")
+            f.write('[remote "origin"]\n')
+            f.write("url = git@github.com:mozilla-services/hsm.git\n")
+            f.write("fetch = +refs/heads/*:refs/remotes/origin/*\n")
+        result = runner.invoke(
+            main, ["check", "--skip-git-fetch", "--config", orchestrator_config_file]
+        )
+        assert (
+            re.search(
+                r"The .* repo has no remotes configured that match",
+                repr(result.exception),
+                flags=re.MULTILINE,
+            )
+            is None
+        )
+        with Path(repo_dir / ".git" / "config").open("w") as f:
+            f.write("[init]\n   defaultBranch = main\n")
+            f.write('[remote "origin"]\n')
+            f.write("url = https://github.com/mozilla-services/hsm.git\n")
+            f.write("fetch = +refs/heads/*:refs/remotes/origin/*\n")
+        result = runner.invoke(
+            main, ["check", "--skip-git-fetch", "--config", orchestrator_config_file]
+        )
+        assert (
+            re.search(
+                r"The .* repo has no remotes configured that match",
+                repr(result.exception),
+                flags=re.MULTILINE,
+            )
+            is None
+        )
+        with Path(repo_dir / ".git" / "config").open("w") as f:
+            f.write("[init]\n   defaultBranch = main\n")
+            f.write('[remote "origin"]\n')
+            f.write("url = https://github.com/mozilla-services/hsm\n")
+            f.write("fetch = +refs/heads/*:refs/remotes/origin/*\n")
+        result = runner.invoke(
+            main, ["check", "--skip-git-fetch", "--config", orchestrator_config_file]
+        )
+        assert (
+            re.search(
+                r"The .* repo has no remotes configured that match",
+                repr(result.exception),
+                flags=re.MULTILINE,
+            )
+            is None
         )
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -218,38 +218,6 @@ def test_git_repo_missing_remote(tmp_path, datafiles):
         )
 
 
-@pytest.mark.datafiles(FIXTURE_DIR / "example.csr")
-def test_running_on_offline_hsm(tmp_path, datafiles):
-    runner = CliRunner()
-    with runner.isolated_filesystem(tmp_path):
-        orchestrator_config_file, repo_dir, csr_dir = set_up_config(
-            tmp_path, configure_paths=True
-        )
-        csr_dir.mkdir()
-        Path(repo_dir / ".git").mkdir()
-        with Path(repo_dir / ".git" / "config").open("w") as f:
-            f.write("[init]\n   defaultBranch = main\n")
-        repo = Repo.init(repo_dir)
-        Path(repo_dir / "certs_issued").mkdir()
-        Path(repo_dir / "file.txt").touch()
-
-        repo.index.commit("Adding file.txt")
-        csr_file = csr_dir / "example.csr"
-        Path(datafiles / "example.csr").rename(csr_file)
-        result = runner.invoke(main, ["check", "--config", orchestrator_config_file])
-        assert type(result.exception) is type(exceptions.RepoNotReady("foo"))
-        assert (
-            re.search(
-                r"The .* repo has no remotes configured that end in"
-                r" mozilla-services/hsm\.git. Make sure the repo is setup with an"
-                r" 'origin' remote pointing to the GitHub repo\.",
-                repr(result.exception),
-                flags=re.MULTILINE,
-            )
-            is not None
-        )
-
-
 @pytest.mark.datafiles(FIXTURE_DIR / "example.csr", FIXTURE_DIR / "malformed.cnf")
 def test_malformed_cnf_file(tmp_path, datafiles, monkeypatch):
     runner = CliRunner()


### PR DESCRIPTION
* Remove duplicated unit test
* Add support for hsm git repo using http
  * This allows http git repo remotes that don't have
    the `.git` suffix in the URL
    This also adds tests for correct and incorrect
    remotes
* Improve GitHub action workflow readability
* Cleanup README formatting
