### PR TITLE
Rename push pull and add post-pull next steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It provides commands to:
 * Push the necessary files to a USB stick for transfer to an offline HSM.
 * Pull back the signed certificate and updated Certificate Authority (CA) files from a USB stick.
 
+[![PyPI - Version](https://img.shields.io/pypi/v/hsm-orchestrator)](https://pypi.org/project/hsm-orchestrator/) [![Tests](https://github.com/mozilla/hsm-orchestrator/actions/workflows/tests.yml/badge.svg)](https://github.com/mozilla/hsm-orchestrator/actions/workflows/tests.yml)
+
 ---
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ run from anywhere.
 If you've configured the tool by creating a `config.ini` file, you don't need to pass the `--repo-dir /path/to/hsm/repo`
 and `--csr-dir /path/to/csrs` arguments.
 
-### Check
+### `check`
 
 `hsm-orchestrator check`
 
 This will perform checks of the environment and your `.csr` and `.cnf` files to make sure that everything is setup
 correctly.
 
-### Push
+### `push-to-stick`
 
-`hsm-orchestrator push`
+`hsm-orchestrator push-to-stick`
 
 This will first check the environment and files, then copy the `.csr`, `.cnf` and the certificate authority files to a
 USB stick along with an instructions text file on what to do on the offline HSM.
@@ -93,12 +93,12 @@ Once you've plugged the USB stick into the offline HSM, you can display the inst
 
 These instructions will explain what commands to run to operate the offline HSM.
 
-### Pull
+### `pull-from-stick`
 
-`hsm-orchestrator pull`
+`hsm-orchestrator pull-from-stick`
 
-After operating the offline HSM and plugging the USB stick back into your workstation, the pull command will move the
-files off of the USB stick and into the correct directories in the hsm git repo.
+After operating the offline HSM and plugging the USB stick back into your workstation, the pull-from-stick command will
+move the files off of the USB stick and into the correct directories in the hsm git repo.
 
 ## Requirements
 
@@ -132,12 +132,12 @@ files off of the USB stick and into the correct directories in the hsm git repo.
       in the `hsm` git repo.
 2. Run `hsm-orchestrator check` to check the settings in the `.cnf` file and the environment.
 3. Insert a blank USB stick in your workstation.
-4. Run `hsm-orchestartor push` to push the files from the `hsm` git repo to the USB stick.
+4. Run `hsm-orchestartor push-to-stick` to push the files from the `hsm` git repo to the USB stick.
 5. Unmount/eject the USB stick from your workstation and plug the stick into the offline HSM.
 6. On the offline HSM, show the instructions by running `cat *.instructions.txt` in the USB stick's directory.
 7. Run the commands described in the instructions. It's easiest to copy and paste them.
 8. Unmount/eject the USB stick from the offline HSM and plug the stick back into your workstation.
-9. Run `hsm-orchestrator pull` to move the signed certificate and update the CA files in the `hsm` git repo.
+9. Run `hsm-orchestrator pull-from-stick` to move the signed certificate and update the CA files in the `hsm` git repo.
 
 ---
 

--- a/hsm_orchestrator/__init__.py
+++ b/hsm_orchestrator/__init__.py
@@ -488,7 +488,7 @@ class HsmOrchestrator:
 # {self.csr_file.with_suffix('.crt').name} will be created
 
 # Once this is done, you can remove the USB stick from the HSM server and plug
-# it back into your laptop and run `hsm-orchestrator pull`
+# it back into your laptop and run `hsm-orchestrator pull-from-stick`
 """
         # TODO : Add a listing of the files that are being copied to the USB stick into
         # the instructions.
@@ -590,7 +590,7 @@ def main() -> None:
     pass
 
 
-@main.command("push")
+@main.command("push-to-stick")
 @click.option(
     "--config",
     "orchestrator_config_filename",
@@ -619,7 +619,7 @@ def main() -> None:
     is_flag=True,
     help="Skip performing a git fetch on the repository",
 )
-def push(
+def push_to_stick(
     orchestrator_config_filename: Path,
     repo_dir: Path,
     csr_dir: Path,
@@ -679,7 +679,7 @@ def push(
     )
 
 
-@main.command("pull")
+@main.command("pull-from-stick")
 @click.option(
     "--config",
     "orchestrator_config_filename",
@@ -701,7 +701,7 @@ def push(
     is_flag=True,
     help="Skip performing a git fetch on the repository",
 )
-def pull(
+def pull_from_stick(
     orchestrator_config_filename: Path, repo_dir: Path, skip_git_fetch: bool
 ) -> None:
     """Pull signed certificates and updated CA files from a USB stick

--- a/hsm_orchestrator/__init__.py
+++ b/hsm_orchestrator/__init__.py
@@ -767,9 +767,11 @@ def pull_from_stick(
     actions.update({x: "delete" for x in remaining_files})
 
     orchestrator.process_usb_files(actions)
-
-
-# TODO : Add textwrap wrap to all echo statements
+    print(
+        "Now that the git repo has been updated with the new files, you likely want "
+        "to commit those changes, push them to the branch and eventually merge the "
+        "branch to main."
+    )
 
 
 @main.command("check")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hsm-orchestrator"
-version = "1.0.2" # REQUIRED, although can be dynamic
+version = "1.1.0"
 description = "Orchestration tool for Mozilla's offline HSM which facilitates conveying a CSR to the air gapped HSM server"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -21,7 +21,12 @@ def test_empty_usb_stick(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert "Which mount is the USB stick you would you like to use" in result.output
@@ -43,7 +48,12 @@ def test_multiple_ca_crt_files(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert (
@@ -63,7 +73,12 @@ def test_no_crt_files(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert (
@@ -84,7 +99,12 @@ def test_missing_crt_related_files(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert (
@@ -109,7 +129,12 @@ def test_missing_ca_related_files(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert "Some of the expected CA files are missing" in result.output
@@ -134,7 +159,12 @@ def test_file_actions_table_output(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         result_lines = Text.from_ansi(result.output).plain.splitlines()
@@ -233,7 +263,12 @@ def test_file_actions(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\ny\n"
         result = runner.invoke(
             main,
-            ["pull", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "pull-from-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert not Path(env["usb_mount_point"] / "test.crt").exists()

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -22,7 +22,12 @@ def test_selecting_usb_stick(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\n"
         result = runner.invoke(
             main,
-            ["push", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "push-to-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert "Which mount is the USB stick you would you like to use" in result.output
@@ -38,7 +43,12 @@ def test_save_usb_stick_to_config(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\ny\n"
         runner.invoke(
             main,
-            ["push", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "push-to-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         with env["orchestrator_config_file"].open("r") as f:
@@ -56,7 +66,12 @@ def test_read_usb_stick_mount_from_config(tmp_path, datafiles, monkeypatch):
         keyboard_input = "y\n"
         result = runner.invoke(
             main,
-            ["push", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "push-to-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert (
@@ -79,7 +94,12 @@ def test_push(tmp_path, datafiles, monkeypatch):
         keyboard_input = f"{env['usb_mount_point']}\nn\n"
         result = runner.invoke(
             main,
-            ["push", "--skip-git-fetch", "--config", env["orchestrator_config_file"]],
+            [
+                "push-to-stick",
+                "--skip-git-fetch",
+                "--config",
+                env["orchestrator_config_file"],
+            ],
             input=keyboard_input,
         )
         assert "The instructions and files have been written to" in result.output


### PR DESCRIPTION
* Rename tests Action
* Add badges to README
* Rename push and pull actions
  * Improve clarity of actions with new names.
  * Fixes #4
* Add note after pull about next steps
* Print a note reminding the operator that they still need to commit and push the git repo
  * Fixes #5
* Update to 1.1.0